### PR TITLE
Beef up README and support Python 3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.virtualenv/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,38 @@
 Potterbot
-===
+=========
 
 Generate Harry Potter-like sentences. Trained using subtitles from http://www.yifysubtitles.com/search?q=harry+potter
 
 Run using `python potterbot.py`
+
+Installation
+============
+
+```bash
+virtualenv .virtualenv --python=python3
+
+.virtualenv/bin/pip install nltk
+```
+
+Sample Output
+=============
+
+Potterbot: Dumbledore made you to the Restricted Section
+
+Potterbot: There you will never forget this morning , Harry was cursed , Ron , I reckon you can be a kind of people 's a little cockroach
+
+Potterbot: This is he 's a quiet to be sufficient quality of you can find it to sink no lower your time already been so what it well , you need any other arm , sir .
+
+Potterbot: Please , go making the night , first task is a stopper in great ugly brute , but as much do you today , wait .
+
+Potterbot: there then he says breakfast 's a troll in the blood will be learning how does n't know me .
+
+Potterbot: - Dress robes ? But who would be counterproductive , obvious , Weasley is perfect I do n't worry .
+
+Potterbot: He had to admit , yeah .
+
+Potterbot: Furthermore , Petunia , enough for a secure the minute or all real loyalty down .
+
+Potterbot: Even with the world will please join You-Know-Who is a broomstick , Ron 's Cross , we 'll go , everybody , Miss Granger .
+
+Potterbot: Hideous

--- a/potterbot.py
+++ b/potterbot.py
@@ -1,6 +1,9 @@
+from __future__ import print_function
+
 import glob
 import random
 import math
+
 from nltk.tokenize import word_tokenize
 from collections import Counter, defaultdict
 
@@ -8,12 +11,12 @@ filenames = glob.glob("*.srt")
 
 language_model = defaultdict(Counter)
 
-print "welcome to the harry potter character emulator"
+print("welcome to the harry potter character emulator")
 
-print "training language model"
+print("training language model")
 for filename in filenames:
     with open(filename) as f:
-        print "Reading lines from {}...".format(filename)
+        print("Reading lines from {}...".format(filename))
 
         # all lines not beginning with a number are dialog lines
         for line in f:
@@ -56,7 +59,7 @@ def generate_sentence():
     return result
 
 # generate 10 sentences
-print
+print()
 for i in range(10):
-    print "Potterbot: {}".format(generate_sentence())
+    print("Potterbot: {}".format(generate_sentence()))
 


### PR DESCRIPTION
Beefs up the README to add installation instructions and sample output.
Converts all `print ""` references to `print("")`, and adds `print_function` import for backwards compatability with Python 2.7.